### PR TITLE
Add notice about AWS native outbound OIDC providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Exchange AWS authentication for OIDC tokens using KMS-backed signing.
 
+> **Update**: AWS has released [outbound OIDC identity providers](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_outbound.html), a built-in feature that provides similar functionality to this project. For new deployments, we recommend evaluating AWS's native solution first, as it requires no infrastructure deployment. This project remains useful if you need additional customization or are already using it in production.
+
 ## ⚠️ Experimental - Unreviewed Code
 
 **This project is experimental and has not undergone security review.** It is provided as a proof-of-concept implementation for exchanging AWS credentials for OIDC tokens. Before using in production:


### PR DESCRIPTION
## Summary

AWS recently released [outbound OIDC identity providers](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_outbound.html), a built-in feature that provides similar functionality to this project.

This PR adds an update notice to the README to inform users about AWS's native solution while clarifying when this project might still be useful (additional customization needs or existing production deployments).

## Changes

- Added update notice at the top of the README
- Linked to AWS's official documentation for outbound OIDC providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)