### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '22'
         cache: 'npm'
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Run shellcheck
       run: |


### PR DESCRIPTION
## Summary
- Pins all GitHub Action references to specific commit SHAs for supply chain security
- Preserves original version tags as comments for readability
- No functional changes - actions resolve to the same versions

## Context
This is part of an org-wide audit to improve GitHub Actions supply chain security.

Generated with Claude Code